### PR TITLE
Removed Google I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ March 17-18 | Game Developers Conference | Streaming on twitch | [twitch.tv](htt
 March 22-26 | Nvidia GTC | Live and on-demand talks | [nvidia.com](https://www.nvidia.com/en-us/gtc/)
 March 31 | Adobe Summit | Keynote and sessions streaming online | [adobe.com](https://www.adobe.com/summit.html)
 May 5-6 | Facebook F8 | Local online events will be scheduled | [f8.com](https://developers.facebook.com/blog/post/2020/02/27/important-f8-2020-update/)
-May 12-14 | Google I/O | Physical conference cancelled. | [google.com](https://events.google.com/io/)
 May 19-21 | Microsoft Build | Online experience planned | [microsoft.com](https://www.microsoft.com/en-us/build)
 June 22-25 | Collision Conference | Online format | [collisionconf.com](https://collisionconf.com/)
 June | Apple WWDC | New online format announced | [apple.com](https://www.apple.com/dk/newsroom/2020/03/apples-wwdc-2020-kicks-off-in-june-with-an-all-new-online-format/)


### PR DESCRIPTION
Google I/O has been cancelled completely.

> Out of concern for the health and safety of our developers, employees, and local communities — and in line with recent “shelter in place” orders by the local Bay Area counties — we sadly will not be holding I/O in any capacity this year. 